### PR TITLE
Update is-buffer and mocha

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,10 +26,10 @@
   "dependencies": {
     "charenc": "~ 0.0.1",
     "crypt": "~ 0.0.1",
-    "is-buffer": "~ 1.0.2"
+    "is-buffer": "~ 1.1.1"
   },
   "devDependencies": {
-    "mocha": "~ 1.4.2"
+    "mocha": "~ 2.3.4"
   },
   "optionalDependencies": {},
   "license": "BSD-3-Clause"


### PR DESCRIPTION
npm v3 tries to dedupe the dependencies by default, and keeping dependencies up-to-date helps better deduplication.
