### PR TITLE
Return undefined when message is null

### DIFF
--- a/md5.js
+++ b/md5.js
@@ -148,7 +148,7 @@
   md5._digestsize = 16;
 
   module.exports = function (message, options) {
-    if(typeof message == 'undefined')
+    if(message === undefined || message === null)
       return;
 
     var digestbytes = crypt.wordsToBytes(md5(message, options));

--- a/test.js
+++ b/test.js
@@ -6,6 +6,14 @@ describe('MD5', function () {
     assert.equal('78e731027d8fd50ed642340b7c9a63b3', md5('message'));
   });
 
+  it('should return "undefined" for "undefined"', function () {
+    assert.equal(undefined, md5(undefined));
+  });
+
+  it('should return "undefined" for "null"', function () {
+    assert.equal(undefined, md5(null));
+  });
+
   it('should not return the same hash for random numbers twice', function () {
     var msg1 = Math.floor((Math.random() * 100000) + 1) + (new Date).getTime();
     var msg2 = Math.floor((Math.random() * 100000) + 1) + (new Date).getTime();


### PR DESCRIPTION
If `md5()` was passed a `null` value then an exception would get thrown:

```
TypeError: Cannot read property 'constructor' of null
  at md5 (md5.js:10:16)
  at module.exports (md5.js:154:42)
```

This commit modifies the function so that when it's passed a `null` value it has
the same behavior as when it's passed an `undefined` value which is to simply
return `undefined`.

---

`null` throwing an exception bit us in the butt with our app. It was easily resolved however by making sure we don't pass `null` to `md5()` in our app code but it'd be useful if `md5()` handled `null` a little more gracefully as well.