### PR TITLE
Run against 0.12, 4.x, 5.x, 6.x to catch more bugs.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,3 +2,8 @@ language: node_js
 node_js:
   - 0.6
   - 0.8
+  - 0.12
+  - 4
+  - 5
+  - 6
+


### PR DESCRIPTION
This just updates `.travis.yml` with more current versions of node.js.
