### PR TITLE
Updating Node.js test versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,5 @@ language: node_js
 node_js:
   - 0.12
   - 4
-  - 5
   - 6
-  - 7
+  - 8


### PR DESCRIPTION
Also drops testing against v5 and v7 because they are out of support and were never LTS.
0.12 should also be dropped because it is EOL, but I'll leave that up for discussion.

https://github.com/nodejs/LTS