### PR TITLE
Update index.html

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -32,7 +32,8 @@ input.onchange = function(e) {
   .then(buffer => {
     console.log(buffer);
     var now = performance.now();
-    var hash = MD5(buffer);
+    var typedArray = new Int32Array(buffer, 0, buffer.byteLength / 4);
+    var hash = MD5(typedArray);
     var after = performance.now() - now;
     output.innerHTML = `
       file: ${file.name}


### PR DESCRIPTION
In browsers, md5( `ArrayBuffer` ) always returns `441018525208457705bf09a8ee3c1093` same as a hash of an empty ArrayBuffer. But if it cast to Int32Array before, it works correctly.

FYI: https://caniuse.com/#search=TypedArray