### PR TITLE
Accept Uint8Array

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ npm install md5
 md5(message)
 ~~~
 
-  * `message` -- `String` or `Buffer`
+  * `message` -- `String`, `Buffer`, `Array` or `Uint8Array`
   * returns `String`
 
 

--- a/md5.js
+++ b/md5.js
@@ -14,7 +14,7 @@
         message = utf8.stringToBytes(message);
     else if (isBuffer(message))
       message = Array.prototype.slice.call(message, 0);
-    else if (!Array.isArray(message))
+    else if (!Array.isArray(message) && message.constructor !== Uint8Array)
       message = message.toString();
     // else, assume byte array already
 

--- a/test.js
+++ b/test.js
@@ -46,4 +46,30 @@ describe('md5', function () {
     var hash3 = md5(hash1 + 'a', { encoding : 'binary' });
     assert.equal(hash3, '131f0ac52813044f5110e4aec638c169');
   });
+
+  it('should support Uint8Array', function() {
+    // Polyfills
+    if (!Array.from) {
+      Array.from = function(src, fn) {
+        var result = new Array(src.length);
+        for (var i = 0; i < src.length; ++i)
+          result[i] = fn(src[i]);
+        return result;
+      };
+    }
+    if (!Uint8Array.from) {
+      Uint8Array.from = function(src) {
+        var result = new Uint8Array(src.length);
+        for (var i = 0; i < src.length; ++i)
+          result[i] = src[i];
+        return result;
+      };
+    }
+
+    var message = 'foobarbaz';
+    var u8arr = Uint8Array.from(
+      Array.from(message, function(c) { return c.charCodeAt(0); }));
+    var u8aHash = md5(u8arr);
+    assert.equal(u8aHash, md5(message));
+  });
 });


### PR DESCRIPTION
Hi @pvorb ,
I want this library to accept `Uint8Array`.

It seems the library already accept `Array`,
and `Uint8Array` is also handled as well.

I don't have necessity for other typed arrays (`Uint8ClampedArray`, etc...),
so added `Uint8Array` only.
